### PR TITLE
Added data within thought schema

### DIFF
--- a/models/Thoughts.js
+++ b/models/Thoughts.js
@@ -1,7 +1,29 @@
 const { Schema, model } = require('mongoose');
 
 // New Schema that creates a thought model
-const thoughtSchema = new Schema();
+const thoughtSchema = new Schema(
+  {
+    // Takes in strings (280 characters max) and is required
+    thoughtText: {
+      type: String,
+      required: true,
+      max_length: 280,
+    },
+
+    // Creates a date and displays the time when each `thoughtText` was created
+    createdAt: {
+      type: Date,
+      default: Date.now,
+      get: (date) => timeSince(date)
+    },
+
+    // Takes in strings and is required
+    username: {
+      type: String,
+      required: true
+    }
+  }
+);
 
 // Takes thoughtSchema and converts it's contents into a model that's stored within 'Thought'
 const Thought = model('thought', thoughtSchema);


### PR DESCRIPTION
I've now added in sectioned data into `thoughtSchema` within `thoughts.js` based off of the `README.md` for the following:

thoughtText:
- String
- Required
- Must be between 1 and 280 characters

createdAt:
- Date
- Set default value to the current timestamp
- Use a getter method to format the timestamp on query

username:
- String
- Required

Here are also the resources I found to help with the following:

- Setting default value to current time stamp: https://stackoverflow.com/questions/36550263/how-create-a-date-field-with-default-value-as-the-current-timestamp-in-mongodb
- Date Formatting: https://stackoverflow.com/questions/70724966/how-to-use-getter-or-setter-with-mongoose-timestamps 

I still need to add in the `reactions` section which will be for next push as I plan on adding in a `reactions.js` file and passing the schema from it to be used in `thoughts.js` file.