### PR TITLE
Added data within reaction schema

### DIFF
--- a/models/reaction.js
+++ b/models/reaction.js
@@ -1,7 +1,36 @@
+const { ObjectId } = require('bson');
 const { Schema, Types } = require('mongoose');
 
 // New Schema for reaction
-const reactionSchema = new Schema();
+const reactionSchema = new Schema(
+  {
+    // Establishes an ID for each reaction
+    reactionID: {
+      type: ObjectId,
+      default: new ObjectId
+    },
+
+    // Takes in strings (280 characters max) and is required
+    reactionBody: {
+      type: String,
+      required: true,
+      max_length: 280
+    },
+
+    // Takes in strings and is required
+    username: {
+      type: String,
+      required: true
+    },
+
+    // Creates a date and displays the time when each `reaction` was created
+    createdAt: {
+      type: Date,
+      default: Date.now,
+      get: (date) => timeSince(date)
+    }
+  }
+);
 
 // Exports 'reactionSchema' to be used in 'thoughts.js'
 module.exports = reactionSchema;


### PR DESCRIPTION
I added the following sectioned data to `reactionSchema` within `reaction.js` based off of the `README.md` provided:

reactionID:
- Use Mongoose's ObjectId data type
- Default value is set to a new ObjectId

reactionBody:
- String
- Required
- 280 character max

username:
- String
- Required

createdAt:
- Date
- Set default value to the current timestamp
- Use a getter method to format the timestamp on query

While these models and schemas are setup (for the most part) I do not know if all of them function the exact way that I need them to (Date and ObjectId in particular) as the database is still not being registered with the connection (to be clear, a connection to mongoDB is successful however it is still unable to create the database) and the code provided is subjected to change because of this.

I will be adding in the seeded data and the routing, eventually coming back to the models to provide touching up and the final additions needed (i.e. `virtuals`).