### PR TITLE
Added routing to display all thoughts

### DIFF
--- a/controllers/thoughtsController.js
+++ b/controllers/thoughtsController.js
@@ -1,3 +1,23 @@
 const { Thought, User } = require('../models');
 
-module.exports = {};
+module.exports = {
+
+  // Async function to retrieve all thoughts
+  async getThoughts(req, res) {
+
+    // Try/Catch statement which will stop running the function if an error is detected
+    try {
+
+      // Takes the model of 'Thoughts' and stores it within 'thoughts'
+      const thoughts = await Thought.find();
+
+      // Responds with the contents of 'thoughts' in JSON formatting
+      res.json(thoughts);
+
+    // If an error is detected it will console log the error in JSON with it's status
+    } catch (err) {
+      console.log(err);
+      return res.status(500).json(err);
+    }
+  },
+};

--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -4,6 +4,6 @@ const thoughtsRoutes = require('./thoughtsRoutes');
 
 // Establishes routing and appending additional routes for `users` and `thoughts`
 router.use('/users', userRoutes);
-// router.use('/thoughts', thoughtsRoutes);
+router.use('/thoughts', thoughtsRoutes);
 
 module.exports = router;

--- a/routes/api/thoughtsRoutes.js
+++ b/routes/api/thoughtsRoutes.js
@@ -1,0 +1,12 @@
+const router = require('express').Router();
+
+// Takes exported functions from 'thoughtsController.js' to be utilized for routing
+const {
+  getThoughts
+} = require('../../controllers/thoughtsController');
+
+// /api/thoughts 
+// Going to this route displays the stored data from 'thoughts' in JSON formatting from the 'GetThoughts' async function call
+router.route('/').get(getThoughts);
+
+module.exports = router;

--- a/routes/api/userRoutes.js
+++ b/routes/api/userRoutes.js
@@ -3,7 +3,7 @@ const router = require('express').Router();
 // Takes exported functions from 'userController.js' to be utilized for routing
 const {
   getUsers
-} = require('../../controllers/userController')
+} = require('../../controllers/userController');
 
 // /api/users 
 // Going to this route displays the stored data from 'userObj' in JSON formatting from the 'GetUsers' async function call


### PR DESCRIPTION
The changes made with this push now allows the user to see (when there is data populated) all thoughts from the `Thoughts` model by going to `/api/thoughts`.

These changes align with how I approached viewing all users from the `User` model but this time simpler by only returning the results of `thoughts` (Line 12) in JSON formatting (Line 15) from `thoughtsController.js` file.

With all that being said, I still need to add in seeding to see how the data is populated, add in the other routes (with their controllers associated of course) and adjust/touch up the models.

This aside from that, this is looking like it is getting close to finishing.